### PR TITLE
Escape character conversion

### DIFF
--- a/DocWorks.Integration.XmlDoc.Driver/Program.cs
+++ b/DocWorks.Integration.XmlDoc.Driver/Program.cs
@@ -25,7 +25,7 @@ namespace DocWorks.Integration.XmlDoc.Driver
         static void Main(string[] args)
         {
             OptionsParser.Prepare(args, typeof(Program).Assembly);
-            DriverOptions.RootPath = "C: \\Users\\Pavan Kumar Reddy\\Desktop\\ErrorTest";
+            DriverOptions.RootPath = "C:\\Users\\Pavan Kumar Reddy\\Desktop\\ErrorTest2";
             var referencedAssemblies = new List<string>();
             if (DriverOptions.ReferencedAssemblies != null)
                 referencedAssemblies.AddRange(DriverOptions.ReferencedAssemblies);
@@ -59,41 +59,43 @@ namespace DocWorks.Integration.XmlDoc.Driver
 
                 var random = new Random();
                 string typeXml = handler.GetTypeDocumentation(id, paths.ToArray());
-                XmlDocument getTypeXml = new XmlDocument();
-                getTypeXml.LoadXml(typeXml);
+                Console.Write(typeXml);
+                handler.SetType(typeXml, paths.ToArray());
+                //XmlDocument getTypeXml = new XmlDocument();
+                //getTypeXml.LoadXml(typeXml);
 
-                if (isOutputDirectorySpecified)
-                    File.WriteAllText(Path.Combine(DriverOptions.OutputDirectory, FixupFilename(id) + ".xml"), typeXml);
+                //if (isOutputDirectorySpecified)
+                //    File.WriteAllText(Path.Combine(DriverOptions.OutputDirectory, FixupFilename(id) + ".xml"), typeXml);
 
-                var xmlDocNodes = getTypeXml.SelectNodes("//xmldoc");
-                HashSet<string> randomComments = new HashSet<string>();
-                foreach (XmlNode xmlDocNode in xmlDocNodes)
-                {
-                    var randomComment = random.Next().ToString();
-                    randomComments.Add(randomComment);
-                    xmlDocNode.ReplaceChild(getTypeXml.CreateCDataSection(randomComment), xmlDocNode.FirstChild);
-                }
+                //var xmlDocNodes = getTypeXml.SelectNodes("//xmldoc");
+                //HashSet<string> randomComments = new HashSet<string>();
+                //foreach (XmlNode xmlDocNode in xmlDocNodes)
+                //{
+                //    var randomComment = random.Next().ToString();
+                //    randomComments.Add(randomComment);
+                //    xmlDocNode.ReplaceChild(getTypeXml.CreateCDataSection(randomComment), xmlDocNode.FirstChild);
+                //}
 
 
-                var tempPaths = paths.ToDictionary(p => p, p =>
-                  {
-                      var tempPath = Path.GetTempFileName();
-                      File.Copy(Path.Combine(DriverOptions.RootPath, p), tempPath, true);
-                      return tempPath;
-                  });
+                //var tempPaths = paths.ToDictionary(p => p, p =>
+                //  {
+                //      var tempPath = Path.GetTempFileName();
+                //      File.Copy(Path.Combine(DriverOptions.RootPath, p), tempPath, true);
+                //      return tempPath;
+                //  });
 
-                var getTypeXmlString = getTypeXml.OuterXml;
-                handler.SetType(getTypeXmlString, paths.ToArray());
-                foreach (var path in paths)
-                {
-                    var fullPath = Path.Combine(DriverOptions.RootPath, path);
-                    var content = File.ReadAllText(fullPath);
-                    randomComments.RemoveWhere(comment => content.Contains("/// " + comment));
-                    File.Copy(tempPaths[path], fullPath, true);
-                }
+                //var getTypeXmlString = getTypeXml.OuterXml;
+                //handler.SetType(getTypeXmlString, paths.ToArray());
+                //foreach (var path in paths)
+                //{
+                //    var fullPath = Path.Combine(DriverOptions.RootPath, path);
+                //    var content = File.ReadAllText(fullPath);
+                //    randomComments.RemoveWhere(comment => content.Contains("/// " + comment));
+                //    File.Copy(tempPaths[path], fullPath, true);
+                //}
 
-                if (randomComments.Count > 0)
-                    Console.WriteLine("Did not write all comments back properly. Xml used to set:\n" + getTypeXmlString);
+                //if (randomComments.Count > 0)
+                //    Console.WriteLine("Did not write all comments back properly. Xml used to set:\n" + getTypeXmlString);
             }
         }
 

--- a/DocWorks.Integration.XmlDoc.Driver/Program.cs
+++ b/DocWorks.Integration.XmlDoc.Driver/Program.cs
@@ -25,15 +25,15 @@ namespace DocWorks.Integration.XmlDoc.Driver
         static void Main(string[] args)
         {
             OptionsParser.Prepare(args, typeof(Program).Assembly);
-
+            DriverOptions.RootPath = "C: \\Users\\Pavan Kumar Reddy\\Desktop\\ErrorTest";
             var referencedAssemblies = new List<string>();
             if (DriverOptions.ReferencedAssemblies != null)
                 referencedAssemblies.AddRange(DriverOptions.ReferencedAssemblies);
 
             var handler = new XMLDocHandler(new CompilationParameters(
                 DriverOptions.RootPath ?? ".",
-                DriverOptions.ExcludedPaths ?? new string[0], 
-                DriverOptions.Defines ?? new string[0], 
+                DriverOptions.ExcludedPaths ?? new string[0],
+                DriverOptions.Defines ?? new string[0],
                 referencedAssemblies));
 
             string typesXml = handler.GetTypesXml();
@@ -75,12 +75,12 @@ namespace DocWorks.Integration.XmlDoc.Driver
                 }
 
 
-                var tempPaths = paths.ToDictionary(p=>p, p =>
-                {
-                    var tempPath = Path.GetTempFileName();
-                    File.Copy(Path.Combine(DriverOptions.RootPath, p), tempPath, true);
-                    return tempPath;
-                });
+                var tempPaths = paths.ToDictionary(p => p, p =>
+                  {
+                      var tempPath = Path.GetTempFileName();
+                      File.Copy(Path.Combine(DriverOptions.RootPath, p), tempPath, true);
+                      return tempPath;
+                  });
 
                 var getTypeXmlString = getTypeXml.OuterXml;
                 handler.SetType(getTypeXmlString, paths.ToArray());

--- a/DocWorks.Integration.XmlDoc.Driver/Program.cs
+++ b/DocWorks.Integration.XmlDoc.Driver/Program.cs
@@ -25,7 +25,6 @@ namespace DocWorks.Integration.XmlDoc.Driver
         static void Main(string[] args)
         {
             OptionsParser.Prepare(args, typeof(Program).Assembly);
-            DriverOptions.RootPath = "C:\\Users\\Pavan Kumar Reddy\\Desktop\\ErrorTest2";
             var referencedAssemblies = new List<string>();
             if (DriverOptions.ReferencedAssemblies != null)
                 referencedAssemblies.AddRange(DriverOptions.ReferencedAssemblies);
@@ -60,42 +59,41 @@ namespace DocWorks.Integration.XmlDoc.Driver
                 var random = new Random();
                 string typeXml = handler.GetTypeDocumentation(id, paths.ToArray());
                 Console.Write(typeXml);
-                handler.SetType(typeXml, paths.ToArray());
-                //XmlDocument getTypeXml = new XmlDocument();
-                //getTypeXml.LoadXml(typeXml);
+                XmlDocument getTypeXml = new XmlDocument();
+                getTypeXml.LoadXml(typeXml);
 
-                //if (isOutputDirectorySpecified)
-                //    File.WriteAllText(Path.Combine(DriverOptions.OutputDirectory, FixupFilename(id) + ".xml"), typeXml);
+                if (isOutputDirectorySpecified)
+                    File.WriteAllText(Path.Combine(DriverOptions.OutputDirectory, FixupFilename(id) + ".xml"), typeXml);
 
-                //var xmlDocNodes = getTypeXml.SelectNodes("//xmldoc");
-                //HashSet<string> randomComments = new HashSet<string>();
-                //foreach (XmlNode xmlDocNode in xmlDocNodes)
-                //{
-                //    var randomComment = random.Next().ToString();
-                //    randomComments.Add(randomComment);
-                //    xmlDocNode.ReplaceChild(getTypeXml.CreateCDataSection(randomComment), xmlDocNode.FirstChild);
-                //}
+                var xmlDocNodes = getTypeXml.SelectNodes("//xmldoc");
+                HashSet<string> randomComments = new HashSet<string>();
+                foreach (XmlNode xmlDocNode in xmlDocNodes)
+                {
+                    var randomComment = random.Next().ToString();
+                    randomComments.Add(randomComment);
+                    xmlDocNode.ReplaceChild(getTypeXml.CreateCDataSection(randomComment), xmlDocNode.FirstChild);
+                }
 
 
-                //var tempPaths = paths.ToDictionary(p => p, p =>
-                //  {
-                //      var tempPath = Path.GetTempFileName();
-                //      File.Copy(Path.Combine(DriverOptions.RootPath, p), tempPath, true);
-                //      return tempPath;
-                //  });
+                var tempPaths = paths.ToDictionary(p => p, p =>
+                  {
+                      var tempPath = Path.GetTempFileName();
+                      File.Copy(Path.Combine(DriverOptions.RootPath, p), tempPath, true);
+                      return tempPath;
+                  });
 
-                //var getTypeXmlString = getTypeXml.OuterXml;
-                //handler.SetType(getTypeXmlString, paths.ToArray());
-                //foreach (var path in paths)
-                //{
-                //    var fullPath = Path.Combine(DriverOptions.RootPath, path);
-                //    var content = File.ReadAllText(fullPath);
-                //    randomComments.RemoveWhere(comment => content.Contains("/// " + comment));
-                //    File.Copy(tempPaths[path], fullPath, true);
-                //}
+                var getTypeXmlString = getTypeXml.OuterXml;
+                handler.SetType(getTypeXmlString, paths.ToArray());
+                foreach (var path in paths)
+                {
+                    var fullPath = Path.Combine(DriverOptions.RootPath, path);
+                    var content = File.ReadAllText(fullPath);
+                    randomComments.RemoveWhere(comment => content.Contains("/// " + comment));
+                    File.Copy(tempPaths[path], fullPath, true);
+                }
 
-                //if (randomComments.Count > 0)
-                //    Console.WriteLine("Did not write all comments back properly. Xml used to set:\n" + getTypeXmlString);
+                if (randomComments.Count > 0)
+                    Console.WriteLine("Did not write all comments back properly. Xml used to set:\n" + getTypeXmlString);
             }
         }
 

--- a/DocWorks.Integration.XmlDoc/DocWorks.Integration.XmlDoc.csproj
+++ b/DocWorks.Integration.XmlDoc/DocWorks.Integration.XmlDoc.csproj
@@ -7,9 +7,9 @@
     <PackageId>DocWorks.Integration.XmlDoc</PackageId>
     <Authors>Unity</Authors>
     <Company>Unity</Company>
-    <Product>DocWorks</Product>
+    <Product>DocTool</Product>
     <Description>DocTool</Description>
-    <Version>1.1.0.2-DocToolChanges</Version>
+    <Version>1.1.0.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/DocWorks.Integration.XmlDoc/DocWorks.Integration.XmlDoc.csproj
+++ b/DocWorks.Integration.XmlDoc/DocWorks.Integration.XmlDoc.csproj
@@ -2,6 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Features>IOperation</Features>
+    <CodeAnalysisRuleSet>..\DocWorksBackEnd.ruleset</CodeAnalysisRuleSet>
+    <PackageId>DocWorks.Integration.XmlDoc</PackageId>
+    <Authors>Unity</Authors>
+    <Company>Unity</Company>
+    <Product>DocWorks</Product>
+    <Description>DocTool</Description>
+    <Version>1.1.0.2-DocToolChanges</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
+++ b/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
@@ -177,9 +177,9 @@ namespace DocWorks.Integration.XmlDoc
         {
             var xml = typeSymbol.GetDocumentationCommentXml();
             xml = extraMemberRegEx.Replace(xml, "");
+            xml = XmlUtility.LegalString(xml);
             //escape end of CDATA tags
             xml = xml.Replace("]]>", "]]]]><![CDATA[>");
-            xml = XmlUtility.LegalString(xml);
             return $@"<![CDATA[{xml}]]>";
         }
 

--- a/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
+++ b/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
@@ -75,7 +75,7 @@ namespace DocWorks.Integration.XmlDoc
         public string GetTypeDocumentation(string id, params string[] paths)
         {
             Dictionary<string, SyntaxTree> treesForPaths = new Dictionary<string, SyntaxTree>();
-            var compilation = ParseAndCompile(treesForPaths, paths);
+            var compilation = ParseAndCompile(treesForPaths);
             var diagnostics = compilation.GetDiagnostics();
 
             var fullPaths = paths.Select(p => Path.GetFullPath(Path.Combine(compilationParameters.RootPath, p)));
@@ -202,7 +202,7 @@ namespace DocWorks.Integration.XmlDoc
             return sb.ToString();
         }
 
-        private CSharpCompilation ParseAndCompile(Dictionary<string, SyntaxTree> treesForPaths, params string[] sourcePaths)
+        private CSharpCompilation ParseAndCompile(Dictionary<string, SyntaxTree> treesForPaths)
         {
             var parserOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
                 SourceCodeKind.Regular, compilationParameters.DefinedSymbols);
@@ -563,7 +563,7 @@ namespace DocWorks.Integration.XmlDoc
         public void SetType(string docXml, params string[] sourcePaths)
         {
             Dictionary<string, SyntaxTree> treesForPaths = new Dictionary<string, SyntaxTree>();
-            var compilation = ParseAndCompile(treesForPaths, sourcePaths);
+            var compilation = ParseAndCompile(treesForPaths);
 
             var fullPaths = sourcePaths.Select(p => Path.GetFullPath(Path.Combine(compilationParameters.RootPath, p)));
 

--- a/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
+++ b/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
@@ -206,38 +206,26 @@ namespace DocWorks.Integration.XmlDoc
         {
             var parserOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
                 SourceCodeKind.Regular, compilationParameters.DefinedSymbols);
-
-            //var csFilePaths = Directory.GetFiles(compilationParameters.RootPath, "*.cs", SearchOption.AllDirectories)
-            //    .Select(Path.GetFullPath);
-
-            //var syntaxTrees = csFilePaths.Select(
-            //    p =>
-            //    {
-            //        var syntaxTree = SyntaxFactory.ParseSyntaxTree(File.ReadAllText(p), parserOptions, p);
-            //        treesForPaths[p] = syntaxTree;
-            //        return syntaxTree;
-            //    }).ToArray();
-
             SyntaxTree[] syntaxTrees = new SyntaxTree[sourcePaths.Count()];
 
             int i = 0;
             foreach (var csFilePath in sourcePaths)
             {
-                Regex regex = new Regex("([\r\n ]*///(.*?)\r?\n)+");
+                Regex regexGetTripleSlashContent = new Regex("([\r\n ]*///(.*?)\r?\n)+");
                 string fullFilePath = Path.GetFullPath(Path.Combine(compilationParameters.RootPath, csFilePath));
                 string csFileContent = File.ReadAllText(fullFilePath);
-                MatchCollection matchCollection = regex.Matches(csFileContent);
+                MatchCollection matchCollection = regexGetTripleSlashContent.Matches(csFileContent);
                 foreach (Match match in matchCollection)
                 {
                     string pattern = @"(?<=<([a-z][^>]*?)>)(.*?)(?=<\/[a-z]*>)";
-                    Regex regex1 = new Regex(pattern, RegexOptions.Singleline);
-                    MatchCollection matchCollection1 = regex1.Matches(match.Value);
-                    foreach (Match match1 in matchCollection1)
+                    Regex regexGetXmlTagContent = new Regex(pattern, RegexOptions.Singleline);
+                    MatchCollection xmlTagMatchCollection = regexGetXmlTagContent.Matches(match.Value);
+                    foreach (Match xmlTagMatch in xmlTagMatchCollection)
                     {
-                        if (!string.IsNullOrEmpty(match1.Value))
+                        if (!string.IsNullOrEmpty(xmlTagMatch.Value))
                         {
-                            string convertedContent = XmlUtility.EscapeString(match1.Value);
-                            csFileContent = csFileContent.Replace(match1.Value, convertedContent);
+                            string convertedContent = XmlUtility.EscapeString(xmlTagMatch.Value);
+                            csFileContent = csFileContent.Replace(xmlTagMatch.Value, convertedContent);
                         }
                     }
                 }

--- a/DocWorks.Integration.XmlDoc/XmlUtility.cs
+++ b/DocWorks.Integration.XmlDoc/XmlUtility.cs
@@ -17,5 +17,15 @@ namespace DocWorks.Integration.XmlDoc
                 .Replace("\"", "&quot;")
                 .Replace("'", "&apos;");
         }
+
+        public static string LegalString(string xmlString)
+        {
+            return xmlString
+                .Replace("&amp;", "&")
+                .Replace("&lt;", "<")
+                .Replace("&gt;", ">")
+                .Replace("&quot;", "\"")
+                .Replace("&apos;", "'");
+        }
     }
 }

--- a/DocWorks.Integration.XmlDoc/XmlUtility.cs
+++ b/DocWorks.Integration.XmlDoc/XmlUtility.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace DocWorks.Integration.XmlDoc
@@ -10,8 +11,9 @@ namespace DocWorks.Integration.XmlDoc
     {
         public static string EscapeString(string xmlString)
         {
+            Regex rgx = new Regex(@"&(?!amp;)(?!lt;)(?!gt;)(?!quot;)(?!apos;)");
+            xmlString = rgx.Replace(xmlString, "&amp;");
             return xmlString
-                .Replace("&", "&amp;")
                 .Replace("<", "&lt;")
                 .Replace(">", "&gt;")
                 .Replace("\"", "&quot;")


### PR DESCRIPTION
This PR Include changes
1. Read Source code file Content documentation.
2. Replacing the Legal characters <, >, &  with corresponding escape characters '&lt;' '&gt;' '&amp' before formatting to Xml in ParseAndCompile() Method call.
3. Replace back those escape characters '&lt;' '&gt;' '&amp' with corresponding Legal characters <, >, & and return output Xml.
4. On SetType() method call, if any escape characters exists will be replaced with Legal characters.