### PR TITLE
Fix perf and generics

### DIFF
--- a/DocWorks.Integration.XmlDoc.Tests/DocWorks.Integration.XmlDoc.Tests.csproj
+++ b/DocWorks.Integration.XmlDoc.Tests/DocWorks.Integration.XmlDoc.Tests.csproj
@@ -49,7 +49,22 @@
     <Compile Update="TestTypes\CameraEditor.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="TestTypes\ClassWithOverloadsDistinctByGenericArguments.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
+    <Compile Update="TestTypes\ClassWithIndexerOverloads.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
     <Compile Update="TestTypes\EscapeCharactersXml.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
+    <Compile Update="TestTypes\Generics\GenericClassWithField.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
+    <Compile Update="TestTypes\Generics\GenericDelegate.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
+    <Compile Update="TestTypes\Generics\GenericMethod.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
     

--- a/DocWorks.Integration.XmlDoc.Tests/GetTypesTests.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/GetTypesTests.cs
@@ -169,6 +169,36 @@ namespace DocWorks.Integration.XmlDoc.Tests
             </relativeFilePaths>
         </type>
         <type>
+          <id>DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics.GenericClassWithField`1</id>
+          <parentId></parentId>
+          <name>GenericClassWithField</name>
+          <kind>Class</kind>
+          <namespace>DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics</namespace>
+          <relativeFilePaths>
+            <path>GenericClassWithField.cs</path>
+          </relativeFilePaths>
+        </type>
+        <type>
+          <id>DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics.GenericDelegate`1</id>
+          <parentId></parentId>
+          <name>GenericDelegate</name>
+          <kind>Delegate</kind>
+          <namespace>DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics</namespace>
+          <relativeFilePaths>
+            <path>GenericDelegate.cs</path>
+          </relativeFilePaths>
+        </type>
+        <type>
+          <id>DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics.GenericMethod</id>
+          <parentId></parentId>
+          <name>GenericMethod</name>
+          <kind>Class</kind>
+          <namespace>DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics</namespace>
+          <relativeFilePaths>
+            <path>GenericMethod.cs</path>
+          </relativeFilePaths>
+        </type>
+        <type>
             <id>DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics.GenericMethodParameter</id>
             <parentId></parentId>
             <name>GenericMethodParameter</name>

--- a/DocWorks.Integration.XmlDoc.Tests/TestTypes/ClassWithIndexerOverloads.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/TestTypes/ClassWithIndexerOverloads.cs
@@ -1,0 +1,30 @@
+﻿using DocWorks.Integration.XmlDoc.Tests.TestTypes.Attributes;
+
+namespace DocWorks.Integration.XmlDoc.Tests.TestTypes
+{
+    public class ClassWithIndexerOverloads
+    {
+        /// <summary>
+        /// int indexer
+        /// </summary>
+        public int this[int a]
+        {
+            get
+            {
+                return 1;
+            }
+            protected set { }
+        }
+        /// <summary>
+        /// string indexer
+        /// </summary>
+        public int this[string a]
+        {
+            get
+            {
+                return 1;
+            }
+            protected set { }
+        }
+    }
+}

--- a/DocWorks.Integration.XmlDoc.Tests/TestTypes/ClassWithOverloadsDistinctByGenericArguments.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/TestTypes/ClassWithOverloadsDistinctByGenericArguments.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace DocWorks.Integration.XmlDoc.Tests.TestTypes
+{
+    public class ClassWithOverloadsDistinctByGenericArguments
+    {
+        /// <summary>
+        /// Method(IEnumerable<int>)
+        /// </summary>
+        public void Method(IEnumerable<int> enumerable) { }
+        /// <summary>
+        /// Method(IEnumerable<byte>)
+        /// </summary>
+        public void Method(IEnumerable<byte> enumerable) { }
+        /// <summary>
+        /// Method(IEnumerable<IEnumerable<int>>)
+        /// </summary>
+        public void Method(IEnumerable<IEnumerable<int>> enumerable) { }
+        /// <summary>
+        /// Method(IEnumerable<IEnumerable<byte>>)
+        /// </summary>
+        public void Method(IEnumerable<IEnumerable<byte>> enumerable) { }
+        /// <summary>
+        /// Method(IEnumerable<IEnumerable<IEnumerable<int>>>)
+        /// </summary>
+        public void Method(IEnumerable<IEnumerable<IEnumerable<int>>> enumerable) { }
+        /// <summary>
+        /// Method(IEnumerable<IEnumerable<IEnumerable<byte>>>)
+        /// </summary>
+        public void Method(IEnumerable<IEnumerable<IEnumerable<byte>>> enumerable) { }
+    }
+}

--- a/DocWorks.Integration.XmlDoc.Tests/TestTypes/Generics/GenericClassWithField.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/TestTypes/Generics/GenericClassWithField.cs
@@ -1,0 +1,13 @@
+﻿namespace DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics
+{
+    /// <summary>
+    /// Existing Docs for GenericClass-T
+    /// </summary>
+    public class GenericClassWithField<T>
+    {
+        /// <summary>
+        /// Existing GenericClass-T.Foo
+        /// </summary>
+        public int Length;
+    }
+}

--- a/DocWorks.Integration.XmlDoc.Tests/TestTypes/Generics/GenericDelegate.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/TestTypes/Generics/GenericDelegate.cs
@@ -1,0 +1,8 @@
+﻿namespace DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics
+{
+
+    /// <summary>
+    /// Delegate type to get a value.
+    /// </summary>
+    public delegate void GenericDelegate<TValue>(ref TValue value);
+}

--- a/DocWorks.Integration.XmlDoc.Tests/TestTypes/Generics/GenericMethod.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/TestTypes/Generics/GenericMethod.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+namespace DocWorks.Integration.XmlDoc.Tests.TestTypes.Generics
+{
+    public class GenericMethod
+    {
+        /// <summary>
+        /// Existing Docs
+        /// </summary>
+        public List<T> Method<T>()
+        {
+            return new List<T>();
+        }
+        /// <summary>
+        /// Existing Docs
+        /// </summary>
+        public void Add<TValue>(string name, int type, IEnumerable<TValue> getter, string metadata = null)
+        {
+        }
+    }
+}

--- a/DocWorks.Integration.XmlDoc/Extensions/TypedConstansExtensions.cs
+++ b/DocWorks.Integration.XmlDoc/Extensions/TypedConstansExtensions.cs
@@ -7,7 +7,7 @@ namespace DocWorks.Integration.XmlDoc.Extensions
     {
         public static string ToCSharpStringNoStringQuotes(this TypedConstant constant)
         {
-            if (constant.Type.QualifiedName(true, true) == "System.String")
+            if (constant.Type.QualifiedName(true, NameFormat.MetadataName) == "System.String")
                 return XmlUtility.EscapeString(SymbolDisplay.FormatPrimitive(constant.Value, false, false));
 
             return constant.ToCSharpString();

--- a/DocWorks.Integration.XmlDoc/GetTypesVisitor.cs
+++ b/DocWorks.Integration.XmlDoc/GetTypesVisitor.cs
@@ -56,7 +56,7 @@ namespace DocWorks.Integration.XmlDoc
 
         public string GetXml()
         {
-            var groups = types.GroupBy(t => t.FullyQualifiedName(true, true));
+            var groups = types.GroupBy(t => t.FullyQualifiedName(true, NameFormat.MetadataName));
             StringBuilder output = new StringBuilder();
 
             output.Append(@"<?xml version=""1.0"" encoding=""utf-16"" standalone=""yes""?>
@@ -101,7 +101,7 @@ namespace DocWorks.Integration.XmlDoc
             if (t.ContainingNamespace.IsGlobalNamespace)
                 return string.Empty;
 
-            return t.ContainingNamespace.FullyQualifiedName(true, false);
+            return t.ContainingNamespace.FullyQualifiedName(true, NameFormat.MetadataName);
         }
 
         internal void Visit(SyntaxNode syntaxNode, SemanticModel semanticModel)

--- a/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
+++ b/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
@@ -33,6 +33,8 @@ namespace DocWorks.Integration.XmlDoc
     public class XMLDocHandler
     {
         private CompilationParameters compilationParameters;
+        private CSharpCompilation csharpCompilation;
+        private Dictionary<string, SyntaxTree> treesForPaths;
 
         public XMLDocHandler(CompilationParameters compilationParameters)
         {
@@ -74,9 +76,7 @@ namespace DocWorks.Integration.XmlDoc
 
         public string GetTypeDocumentation(string id, params string[] paths)
         {
-            Dictionary<string, SyntaxTree> treesForPaths = new Dictionary<string, SyntaxTree>();
-            var compilation = ParseAndCompile(treesForPaths);
-            var diagnostics = compilation.GetDiagnostics();
+            EnsureCompiled();
 
             var fullPaths = paths.Select(p => Path.GetFullPath(Path.Combine(compilationParameters.RootPath, p)));
 
@@ -87,17 +87,17 @@ namespace DocWorks.Integration.XmlDoc
                 if (!treesForPaths.TryGetValue(path, out syntaxTree))
                     throw new ArgumentException("File \"" + path + "\" does not exist or was not found under root \"" + compilationParameters.RootPath + "\"");
 
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var semanticModel = csharpCompilation.GetSemanticModel(syntaxTree);
 
                 var descendants = syntaxTree.GetRoot().DescendantNodes();
                 var res = descendants.OfType<BaseTypeDeclarationSyntax>().Cast<MemberDeclarationSyntax>().Concat(descendants.OfType<DelegateDeclarationSyntax>()).ToArray();
                 foreach (var typeDeclaration in res)
                 {
                     var typeSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration) as INamedTypeSymbol;
-                    if (id == typeSymbol.QualifiedName(true, true))
+                    if (id == typeSymbol.QualifiedName(true, NameFormat.MetadataName))
                     {
                         var containingType = typeSymbol.ContainingType != null ?
-                            $@"containingType=""{typeSymbol.ContainingType.FullyQualifiedName(false, true)}"" " :
+                            $@"containingType=""{typeSymbol.ContainingType.FullyQualifiedName(false, NameFormat.MetadataName)}"" " :
                             string.Empty;
 
 
@@ -123,7 +123,7 @@ namespace DocWorks.Integration.XmlDoc
 
                         var xml = new StringBuilder($@"<?xml version=""1.0"" encoding=""utf-16"" standalone=""yes""?>
 <doc version=""3"">
-    <member name=""{typeSymbol.MetadataName}"" type=""{typeSymbol.TypeKind}"" {containingType}namespace=""{typeSymbol.ContainingNamespace.FullyQualifiedName(true, true)}""{xmlAttributes}>
+    <member name=""{typeSymbol.MetadataName}"" type=""{typeSymbol.TypeKind}"" {containingType}namespace=""{typeSymbol.ContainingNamespace.FullyQualifiedName(true, NameFormat.MetadataName)}""{xmlAttributes}>
         {InterfaceList(typeSymbol)}
         {TypeParametersXmlForDeclaration(typeSymbol.TypeParameters)}
         {extraContent}
@@ -202,8 +202,12 @@ namespace DocWorks.Integration.XmlDoc
             return sb.ToString();
         }
 
-        private CSharpCompilation ParseAndCompile(Dictionary<string, SyntaxTree> treesForPaths)
+        private void EnsureCompiled()
         {
+            if (treesForPaths != null)
+                return;
+
+            treesForPaths = new Dictionary<string, SyntaxTree>();
             var parserOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
                 SourceCodeKind.Regular, compilationParameters.DefinedSymbols);
 
@@ -236,8 +240,7 @@ namespace DocWorks.Integration.XmlDoc
 
             var compilerOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
             compilerOptions = compilerOptions.WithAllowUnsafe(true);
-            var compilation = CSharpCompilation.Create("Test", syntaxTrees, GetMetadataReferences(), compilerOptions);
-            return compilation;
+            csharpCompilation = CSharpCompilation.Create("Test", syntaxTrees, GetMetadataReferences(), compilerOptions);
         }
 
         private static string AttributesXml(ISymbol typeSymbol)
@@ -320,7 +323,7 @@ namespace DocWorks.Integration.XmlDoc
             if (typeSymbol.TypeKind == TypeKind.Interface || typeSymbol.TypeKind == TypeKind.Struct)
                 return null;
 
-            if (typeSymbol.BaseType.FullyQualifiedName(true, true) == "System.Object")
+            if (typeSymbol.BaseType.FullyQualifiedName(true, NameFormat.MetadataName) == "System.Object")
                 return null;
 
             return typeSymbol.BaseType.Id();
@@ -567,8 +570,7 @@ namespace DocWorks.Integration.XmlDoc
 
         public void SetType(string docXml, params string[] sourcePaths)
         {
-            Dictionary<string, SyntaxTree> treesForPaths = new Dictionary<string, SyntaxTree>();
-            var compilation = ParseAndCompile(treesForPaths);
+            EnsureCompiled();
 
             var fullPaths = sourcePaths.Select(p => Path.GetFullPath(Path.Combine(compilationParameters.RootPath, p)));
 
@@ -586,7 +588,7 @@ namespace DocWorks.Integration.XmlDoc
                 if (!treesForPaths.TryGetValue(fullPath, out syntaxTree))
                     throw new ArgumentException(fullPath + " is not contained in root path " + compilationParameters.RootPath);
 
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var semanticModel = csharpCompilation.GetSemanticModel(syntaxTree);
                 partialInfoCollector.Visit(syntaxTree.GetRoot(), semanticModel);
             }
 
@@ -594,7 +596,7 @@ namespace DocWorks.Integration.XmlDoc
             foreach (var fullPath in fullPaths)
             {
                 var syntaxTree = treesForPaths[fullPath];
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var semanticModel = csharpCompilation.GetSemanticModel(syntaxTree);
                 var result = docUpdater.Visit(syntaxTree.GetRoot(), semanticModel);
 
                 if (result != syntaxTree.GetRoot())
@@ -744,7 +746,7 @@ namespace DocWorks.Integration.XmlDoc
         public override void VisitClassDeclaration(ClassDeclarationSyntax node)
         {
             var symbol = _semanticModel.GetDeclaredSymbol(node);
-            var symbolId = symbol.QualifiedName(true, true);
+            var symbolId = symbol.QualifiedName(true, NameFormat.MetadataName);
             if (symbolId == _id)
             {
 

--- a/DocWorks.Integration.XmlDoc/XmlDocReplacerVisitor.cs
+++ b/DocWorks.Integration.XmlDoc/XmlDocReplacerVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -108,9 +109,9 @@ namespace DocWorks.Integration.XmlDoc
         private XmlNode SelectTypeNode(INamedTypeSymbol typeSymbol)
         {
             var selector =
-                new StringBuilder($"@name='{typeSymbol.MetadataName}' and @namespace='{typeSymbol.ContainingNamespace.FullyQualifiedName(true, true)}'");
+                new StringBuilder($"@name='{typeSymbol.MetadataName}' and @namespace='{typeSymbol.ContainingNamespace.FullyQualifiedName(true, NameFormat.MetadataName)}'");
             if (typeSymbol.ContainingType != null)
-                selector.Append($" and @containingType='{typeSymbol.ContainingType.FullyQualifiedName(false, true)}'");
+                selector.Append($" and @containingType='{typeSymbol.ContainingType.FullyQualifiedName(false, NameFormat.MetadataName)}'");
 
             var docNodes = _xmlDoc.SelectNodes($"descendant::member[{selector}]");
             if (docNodes.Count > 1)
@@ -138,17 +139,27 @@ namespace DocWorks.Integration.XmlDoc
                 return nodeToUpdate;
 
             var constraints = "";
-            var methodSymbol = symbol as IMethodSymbol;
-            if (methodSymbol != null)
+
+            ImmutableArray<IParameterSymbol> parameters = default(ImmutableArray<IParameterSymbol>);
+            if (symbol is IMethodSymbol)
+                parameters = ((IMethodSymbol) symbol).Parameters;
+
+            if (symbol is IPropertySymbol)
+                parameters = ((IPropertySymbol) symbol).Parameters;
+
+            if (!parameters.IsDefault)
             {
                 int xpathIdx = 1;
-                foreach (var parameter in methodSymbol.Parameters)
+                foreach (var parameter in parameters)
                 {
                     var parameterType = parameter.Type;
                     if (parameterType is ITypeParameterSymbol)
                         constraints += $@" and signature/parameters/parameter[{xpathIdx}]/typeParameter/@name='{parameterType.Name}'";
                     else
-                        constraints += $@" and signature/parameters/parameter[{xpathIdx}]/type/@typeId='{parameterType.Id()}'";
+                    {
+                        var constraintPrefix = $@" and signature/parameters/parameter[{xpathIdx}]/";
+                        constraints = AddTypeConstraints(constraints, constraintPrefix, parameterType);
+                    }
 
                     xpathIdx++;
                 }
@@ -158,6 +169,26 @@ namespace DocWorks.Integration.XmlDoc
             var docNodes = parentNode.SelectNodes($"member[@name='{symbol.MemberNameUnescaped()}'{constraints}]/xmldoc");
 
             return AddOrUpdateXmlDoc(originalNode, nodeToUpdate, docNodes, symbol);
+        }
+
+        private static string AddTypeConstraints(string constraints, string constraintPrefix, ITypeSymbol parameterType)
+        {
+            var isTypeParameter = parameterType is ITypeParameterSymbol;
+            if (isTypeParameter)
+                constraints += $@"{constraintPrefix}typeParameter/@name='{parameterType.Name}'";
+            else
+                constraints += $@"{constraintPrefix}type/@typeId='{parameterType.Id()}'";
+
+            if (parameterType is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.IsGenericType)
+            {
+                foreach (var typeParameterSymbol in namedTypeSymbol.TypeArguments)
+                {
+                    var subTypeConstraintPrefix = $@"{constraintPrefix}type[@typeId='{parameterType.Id()}']/typeArguments/";
+                    constraints = AddTypeConstraints(constraints, subTypeConstraintPrefix, typeParameterSymbol);
+                }
+            }
+
+            return constraints;
         }
 
         private SyntaxNode AddOrUpdateXmlDoc(SyntaxNode originalNode, SyntaxNode nodeToBeUpdated, XmlNodeList matchingDocNodes, ISymbol symbol)
@@ -221,7 +252,7 @@ namespace DocWorks.Integration.XmlDoc
 
         private XmlNodeList XmlDocNodeForMember(ISymbol symbol)
         {
-            return _xmlDoc.SelectNodes($"descendant::member[@name='{symbol.ContainingType.Name}']/member[@name='{symbol.MemberNameUnescaped()}']/xmldoc");
+            return _xmlDoc.SelectNodes($"descendant::member[@name='{symbol.ContainingType.MetadataName}']/member[@name='{symbol.MemberNameUnescaped()}']/xmldoc");
         }
 
     }


### PR DESCRIPTION
Addressing perf issues in XMLDocHandler by holding on to compilation results across queries. Also fixing a number of bugs regarding generics and indexers found when running on \DocWorksLargeRepo\src\Microsoft.ML.Core