### PR TITLE
changes

### DIFF
--- a/DocWorks.Integration.XmlDoc/DocWorks.Integration.XmlDoc.csproj
+++ b/DocWorks.Integration.XmlDoc/DocWorks.Integration.XmlDoc.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,7 +9,7 @@
     <Company>Unity</Company>
     <Product>DocTool</Product>
     <Description>DocTool</Description>
-    <Version>1.1.0.2</Version>
+    <Version>1.1.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
+++ b/DocWorks.Integration.XmlDoc/XMLDocHandler.cs
@@ -71,6 +71,8 @@ namespace DocWorks.Integration.XmlDoc
                 getTypesVisitor.Visit(syntaxTree.GetRoot(), semanticModel);
             }
 
+            EnsureCompiled();
+
             return FormatXml(getTypesVisitor.GetXml());
         }
 
@@ -101,7 +103,7 @@ namespace DocWorks.Integration.XmlDoc
                             string.Empty;
 
 
-                        
+
                         string xmlAttributes = "";
                         var baseType = BaseType(typeSymbol);
                         if (!string.IsNullOrEmpty(baseType))


### PR DESCRIPTION
I am raising this PR to resolve the caching issue. We have to put the XmlDocHandler object after 1st compilation only.
GetTypeDocumentation is called by multiple threads simultaneously so, we have to compile it in GetTypesXml function itself as this is the function which is being called once for each preprocessor.