### PR TITLE
Failing test case for member with ref argument

### DIFF
--- a/DocWorks.Integration.XmlDoc.Tests/DocWorks.Integration.XmlDoc.Tests.csproj
+++ b/DocWorks.Integration.XmlDoc.Tests/DocWorks.Integration.XmlDoc.Tests.csproj
@@ -25,6 +25,9 @@
     <Compile Update="TestTypes\Attributes\ClassWithAttributes.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="TestTypes\ClassWithMemberWithRefArgument.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
     <Compile Update="TestTypes\Attributes\ClassWithAttributeWithStringArgument.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>

--- a/DocWorks.Integration.XmlDoc.Tests/GetTypesTests.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/GetTypesTests.cs
@@ -1326,6 +1326,20 @@ namespace DocWorks.Integration.XmlDoc.Tests
             else
                 AssertXmlContains(data.expectedXml, actualXml);
         }
+        
+        [Test]
+        public void GivenType_WithAMember_HavingRefArgument_GetTypeDocumentation_ShouldReturn_SomeIndicatorForRef()
+        {
+            CompilationParameters compilationParameters = new CompilationParameters(".", Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+            var handler = new XMLDocHandler(compilationParameters);
+            string actualXml = handler.GetTypeDocumentation("DocWorks.Integration.XmlDoc.Tests.TestTypes.ClassWithMemberWithRefArgument", "TestTypes/ClassWithMemberWithRefArgument.cs");
+            var doc = new XmlDocument();
+            doc.LoadXml(actualXml);
+            XmlNodeList nodes = doc.DocumentElement.SelectNodes("member/member[@name='RefMember']/signature/parameters");
+            Assert.That(nodes[0].InnerXml, Is.Not.EqualTo(nodes[1].InnerXml));
+            XmlNodeList nodesStatic = doc.DocumentElement.SelectNodes("member/member[@name='RefMemberStatic']/signature/parameters");
+            Assert.That(nodesStatic[0].InnerXml, Is.Not.EqualTo(nodesStatic[1].InnerXml));
+        }
 
         private void AssertValidXml(string actualXml)
         {

--- a/DocWorks.Integration.XmlDoc.Tests/TestTypes/ClassWithMemberWithRefArgument.cs
+++ b/DocWorks.Integration.XmlDoc.Tests/TestTypes/ClassWithMemberWithRefArgument.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DocWorks.Integration.XmlDoc.Tests.TestTypes
+{
+    public class ClassWithMemberWithRefArgument
+    {
+        public void RefMember(ref Object o)
+        {
+
+        }
+
+        public void RefMember(Object o)
+        {
+
+        }
+
+        public static void RefMemberStatic(ref Object o)
+        {
+
+        }
+
+        public static void RefMemberStatic(Object o)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Shows same data is returned for member with ref argument and for one without